### PR TITLE
Start Supabase bot management

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ NEXT_PUBLIC_SUPABASE_URL=your-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-key
 ```
 
+## Features
+
+- Supabase-backed API routes for creating and updating bots.
+- Dashboard pages to list bots, create a new one and edit their flow using a simple React Flow editor.
+

--- a/app/api/bots/[id]/route.ts
+++ b/app/api/bots/[id]/route.ts
@@ -1,0 +1,50 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data, error } = await supabase
+    .from('bots')
+    .select('*')
+    .eq('id', params.id)
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const updates = await request.json()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data, error } = await supabase
+    .from('bots')
+    .update({ ...updates })
+    .eq('id', params.id)
+    .eq('owner_id', session.user.id)
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}

--- a/app/api/bots/route.ts
+++ b/app/api/bots/route.ts
@@ -1,0 +1,41 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json([], { status: 401 })
+  }
+  const { data, error } = await supabase
+    .from('bots')
+    .select('*')
+    .eq('owner_id', session.user.id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const { name, flow_json } = await request.json()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data, error } = await supabase
+    .from('bots')
+    .insert({ name, flow_json, owner_id: session.user.id })
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}

--- a/app/dashboard/bots/[id]/edit/page.tsx
+++ b/app/dashboard/bots/[id]/edit/page.tsx
@@ -1,0 +1,31 @@
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import BotFlowEditor from '@/components/BotFlowEditor'
+
+export default async function EditBotPage({ params }: { params: { id: string } }) {
+  const supabase = createServerComponentClient({ cookies })
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    redirect('/login')
+  }
+
+  const { data: bot } = await supabase
+    .from('bots')
+    .select('*')
+    .eq('id', params.id)
+    .single()
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">{bot?.name}</h1>
+      <BotFlowEditor
+        botId={params.id}
+        initialNodes={bot?.flow_json?.nodes || []}
+        initialEdges={bot?.flow_json?.edges || []}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/bots/new/page.tsx
+++ b/app/dashboard/bots/new/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function NewBotPage() {
+  const [name, setName] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  const createBot = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    const res = await fetch('/api/bots', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, flow_json: { nodes: [], edges: [] } }),
+    })
+    setLoading(false)
+    if (res.ok) {
+      const bot = await res.json()
+      router.push(`/dashboard/bots/${bot.id}/edit`)
+    }
+  }
+
+  return (
+    <form onSubmit={createBot} className="max-w-sm mx-auto p-8 space-y-4">
+      <h1 className="text-2xl font-bold">New Bot</h1>
+      <input
+        className="w-full border p-2"
+        type="text"
+        placeholder="Bot Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <button className="w-full bg-black text-white p-2" type="submit">
+        {loading ? 'Creating...' : 'Create'}
+      </button>
+    </form>
+  )
+}

--- a/app/dashboard/bots/page.tsx
+++ b/app/dashboard/bots/page.tsx
@@ -1,0 +1,41 @@
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+export default async function BotsPage() {
+  const supabase = createServerComponentClient({ cookies })
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    redirect('/login')
+  }
+
+  const { data: bots } = await supabase
+    .from('bots')
+    .select('id, name')
+    .eq('owner_id', session.user.id)
+    .order('created_at', { ascending: false })
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">My Bots</h1>
+      <Link
+        href="/dashboard/bots/new"
+        className="mb-4 inline-block bg-black text-white p-2 rounded"
+      >
+        New Bot
+      </Link>
+      <ul className="mt-4 space-y-2">
+        {bots?.map((bot) => (
+          <li key={bot.id}>
+            <Link href={`/dashboard/bots/${bot.id}/edit`} className="underline">
+              {bot.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,12 +6,21 @@ import { useRouter } from 'next/navigation'
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
   const router = useRouter()
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError('')
+    setLoading(true)
     const { error } = await supabase.auth.signInWithPassword({ email, password })
-    if (!error) router.push('/dashboard')
+    setLoading(false)
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/dashboard')
+    }
   }
 
   return (
@@ -32,8 +41,9 @@ export default function LoginPage() {
         onChange={(e) => setPassword(e.target.value)}
       />
       <button className="w-full bg-black text-white p-2" type="submit">
-        Login
+        {loading ? 'Loading...' : 'Login'}
       </button>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
     </form>
   )
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -6,12 +6,21 @@ import { useRouter } from 'next/navigation'
 export default function SignupPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
   const router = useRouter()
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError('')
+    setLoading(true)
     const { error } = await supabase.auth.signUp({ email, password })
-    if (!error) router.push('/dashboard')
+    setLoading(false)
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/dashboard')
+    }
   }
 
   return (
@@ -32,8 +41,9 @@ export default function SignupPage() {
         onChange={(e) => setPassword(e.target.value)}
       />
       <button className="w-full bg-black text-white p-2" type="submit">
-        Sign Up
+        {loading ? 'Loading...' : 'Sign Up'}
       </button>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
     </form>
   )
 }

--- a/components/BotFlowEditor.tsx
+++ b/components/BotFlowEditor.tsx
@@ -1,0 +1,67 @@
+'use client'
+import ReactFlow, {
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  Background,
+  Controls,
+  MiniMap,
+  type Connection,
+  type Edge,
+  type Node,
+  EdgeChange,
+  NodeChange,
+} from 'react-flow-renderer'
+import { useCallback, useState } from 'react'
+
+type Props = {
+  botId: string
+  initialNodes: Node[]
+  initialEdges: Edge[]
+}
+
+export default function BotFlowEditor({ botId, initialNodes, initialEdges }: Props) {
+  const [nodes, setNodes] = useState<Node[]>(initialNodes)
+  const [edges, setEdges] = useState<Edge[]>(initialEdges)
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setNodes((nds) => applyNodeChanges(changes, nds)),
+    []
+  )
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+    []
+  )
+  const onConnect = useCallback(
+    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    []
+  )
+
+  const saveFlow = async () => {
+    await fetch(`/api/bots/${botId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ flow_json: { nodes, edges } }),
+    })
+  }
+
+  return (
+    <div className="h-[500px] bg-white">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        fitView
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+      <button className="mt-4 p-2 bg-black text-white" onClick={saveFlow}>
+        Save
+      </button>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-flow-renderer": "^10.3.17",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "ui": "git+https://github.com/shadcn/ui.git"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@supabase/auth-helpers-nextjs':
+        specifier: ^0.10.0
+        version: 0.10.0(@supabase/supabase-js@2.50.0)
       '@supabase/supabase-js':
         specifier: ^2.50.0
         version: 2.50.0
@@ -968,6 +971,18 @@ packages:
   '@sindresorhus/is@0.14.0':
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
+
+  '@supabase/auth-helpers-nextjs@0.10.0':
+    resolution: {integrity: sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==}
+    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
+    peerDependencies:
+      '@supabase/supabase-js': ^2.39.8
+
+  '@supabase/auth-helpers-shared@0.7.0':
+    resolution: {integrity: sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==}
+    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
+    peerDependencies:
+      '@supabase/supabase-js': ^2.39.8
 
   '@supabase/auth-js@2.70.0':
     resolution: {integrity: sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==}
@@ -2834,6 +2849,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3797,6 +3815,9 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5407,6 +5428,17 @@ snapshots:
 
   '@sindresorhus/is@0.14.0': {}
 
+  '@supabase/auth-helpers-nextjs@0.10.0(@supabase/supabase-js@2.50.0)':
+    dependencies:
+      '@supabase/auth-helpers-shared': 0.7.0(@supabase/supabase-js@2.50.0)
+      '@supabase/supabase-js': 2.50.0
+      set-cookie-parser: 2.7.1
+
+  '@supabase/auth-helpers-shared@0.7.0(@supabase/supabase-js@2.50.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.50.0
+      jose: 4.15.9
+
   '@supabase/auth-js@2.70.0':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -6712,7 +6744,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -6751,7 +6783,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6766,7 +6798,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7509,6 +7541,8 @@ snapshots:
   jiti@2.4.2: {}
 
   jju@1.4.0: {}
+
+  jose@4.15.9: {}
 
   js-tokens@4.0.0: {}
 
@@ -8469,6 +8503,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.2: {}
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- improve login & signup with error handling
- add @supabase/auth-helpers-nextjs dependency
- create API routes for bots and a React Flow based editor
- add pages to create, edit and list bots

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ESLint interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6847f34e25248324a50730f119fda7fa