### PR TITLE
Fix EditBotPage param type

### DIFF
--- a/app/dashboard/bots/[id]/edit/page.tsx
+++ b/app/dashboard/bots/[id]/edit/page.tsx
@@ -3,7 +3,8 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import BotFlowEditor from '@/components/BotFlowEditor'
 
-export default async function EditBotPage({ params }: { params: { id: string } }) {
+export default async function EditBotPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   const supabase = createServerComponentClient({ cookies })
   const {
     data: { session },
@@ -15,14 +16,14 @@ export default async function EditBotPage({ params }: { params: { id: string } }
   const { data: bot } = await supabase
     .from('bots')
     .select('*')
-    .eq('id', params.id)
+    .eq('id', id)
     .single()
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">{bot?.name}</h1>
       <BotFlowEditor
-        botId={params.id}
+        botId={id}
         initialNodes={bot?.flow_json?.nodes || []}
         initialEdges={bot?.flow_json?.edges || []}
       />


### PR DESCRIPTION
## Summary
- fix params type for the Edit Bot page to accept an async param

## Testing
- `pnpm run build` *(fails: Supabase env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_68495f509ccc8324a1a13012b431b02b