### PR TITLE
Support SUPABASE_URL fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ NEXT_PUBLIC_SUPABASE_URL=your-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-key
 ```
 
+Alternatively you can use environment variables named `SUPABASE_URL` and
+`SUPABASE_PUBLIC`. When using these names, be sure they are exposed to the client
+(for example by prefixing them with `NEXT_PUBLIC_` in `next.config.ts` or your
+deployment settings).
+
 ## Features
 
 - Supabase-backed API routes for creating and updating bots.

--- a/app/api/bots/[id]/route.ts
+++ b/app/api/bots/[id]/route.ts
@@ -6,7 +6,15 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = createRouteHandlerClient({ cookies })
+  const supabase = createRouteHandlerClient(
+    { cookies },
+    {
+      supabaseUrl:
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
   const {
     data: { session },
   } = await supabase.auth.getSession()
@@ -29,7 +37,15 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = createRouteHandlerClient({ cookies })
+  const supabase = createRouteHandlerClient(
+    { cookies },
+    {
+      supabaseUrl:
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
   const updates = await request.json()
   const {
     data: { session },

--- a/app/api/bots/route.ts
+++ b/app/api/bots/route.ts
@@ -3,7 +3,15 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies })
+  const supabase = createRouteHandlerClient(
+    { cookies },
+    {
+      supabaseUrl:
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
   const {
     data: { session },
   } = await supabase.auth.getSession()
@@ -21,7 +29,15 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const supabase = createRouteHandlerClient({ cookies })
+  const supabase = createRouteHandlerClient(
+    { cookies },
+    {
+      supabaseUrl:
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
   const { name, flow_json } = await request.json()
   const {
     data: { session },

--- a/app/dashboard/bots/[id]/edit/page.tsx
+++ b/app/dashboard/bots/[id]/edit/page.tsx
@@ -5,7 +5,15 @@ import BotFlowEditor from '@/components/BotFlowEditor'
 
 export default async function EditBotPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerComponentClient(
+    { cookies },
+    {
+      supabaseUrl:
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/app/dashboard/bots/page.tsx
+++ b/app/dashboard/bots/page.tsx
@@ -4,7 +4,15 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 export default async function BotsPage() {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerComponentClient(
+    { cookies },
+    {
+      supabaseUrl:
+        process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co'
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'public-anon-key'
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  'https://example.supabase.co'
+
+const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_PUBLIC ||
+  'public-anon-key'
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- check `SUPABASE_URL` and `SUPABASE_PUBLIC` when creating the Supabase client
- forward the same values when creating server clients
- document fallback variable names in the README

## Testing
- `pnpm exec next lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_684a06eec7d08324a7a1c30b34c3c413