### PR TITLE
Implement password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-key
 
 - Supabase-backed API routes for creating and updating bots.
 - Dashboard pages to list bots, create a new one and edit their flow using a simple React Flow editor.
+- Forgot password and password reset pages powered by Supabase.
+
+## Password Reset Flow
+
+1. From the login page, click **Forgot your password?**.
+2. Enter your email on `/forgot-password` to receive a magic link.
+3. Follow the link in your email, which opens `/reset-password`.
+4. Choose a new password and submit the form to update your account.
 

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { supabase } from '@/lib/supabaseClient'
+import { useState } from 'react'
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleReset = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setMessage('')
+    setLoading(true)
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/reset-password`,
+    })
+    setLoading(false)
+    if (error) {
+      setError(error.message)
+    } else {
+      setMessage('Check your email for the reset link.')
+    }
+  }
+
+  return (
+    <form onSubmit={handleReset} className="max-w-sm mx-auto p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Forgot Password</h1>
+      <input
+        className="w-full border p-2"
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <button className="w-full bg-black text-white p-2" type="submit">
+        {loading ? 'Loading...' : 'Send Reset Link'}
+      </button>
+      {message && <p className="text-green-600 text-sm">{message}</p>}
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+    </form>
+  )
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -2,52 +2,44 @@
 import { supabase } from '@/lib/supabaseClient'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
 
-export default function LoginPage() {
-  const [email, setEmail] = useState('')
+export default function ResetPasswordPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+  const [message, setMessage] = useState('')
   const [loading, setLoading] = useState(false)
   const router = useRouter()
 
-  const handleLogin = async (e: React.FormEvent) => {
+  const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+    setMessage('')
     setLoading(true)
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    const { error } = await supabase.auth.updateUser({ password })
     setLoading(false)
     if (error) {
       setError(error.message)
     } else {
-      router.push('/dashboard')
+      setMessage('Password updated. You can now log in.')
+      router.push('/login')
     }
   }
 
   return (
-    <form onSubmit={handleLogin} className="max-w-sm mx-auto p-8 space-y-4">
-      <h1 className="text-2xl font-bold">Login</h1>
-      <input
-        className="w-full border p-2"
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
+    <form onSubmit={handleUpdate} className="max-w-sm mx-auto p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Reset Password</h1>
       <input
         className="w-full border p-2"
         type="password"
-        placeholder="Password"
+        placeholder="New password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
       <button className="w-full bg-black text-white p-2" type="submit">
-        {loading ? 'Loading...' : 'Login'}
+        {loading ? 'Loading...' : 'Update Password'}
       </button>
+      {message && <p className="text-green-600 text-sm">{message}</p>}
       {error && <p className="text-red-500 text-sm">{error}</p>}
-      <Link href="/forgot-password" className="text-sm text-blue-600 underline">
-        Forgot your password?
-      </Link>
     </form>
   )
 }


### PR DESCRIPTION
## Summary
- create a page for requesting a reset email
- handle password update from the magic link
- link to the new flow from the login page
- document the new reset workflow

## Testing
- `pnpm lint` *(fails: ESLint tries to initialize interactively)*

------
https://chatgpt.com/codex/tasks/task_e_684a06f5db748324b83c44c7ef6b24a4