### PR TITLE
Fix route params type

### DIFF
--- a/app/api/bots/[id]/route.ts
+++ b/app/api/bots/[id]/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const supabase = createRouteHandlerClient({ cookies })
   const {
@@ -13,11 +13,10 @@ export async function GET(
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  const { id } = await params
   const { data, error } = await supabase
     .from('bots')
     .select('*')
-    .eq('id', id)
+    .eq('id', params.id)
     .single()
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })
@@ -27,7 +26,7 @@ export async function GET(
 
 export async function PUT(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const supabase = createRouteHandlerClient({ cookies })
   const updates = await request.json()
@@ -37,11 +36,10 @@ export async function PUT(
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  const { id } = await params
   const { data, error } = await supabase
     .from('bots')
     .update({ ...updates })
-    .eq('id', id)
+    .eq('id', params.id)
     .eq('owner_id', session.user.id)
     .select()
     .single()

--- a/app/dashboard/bots/[id]/edit/page.tsx
+++ b/app/dashboard/bots/[id]/edit/page.tsx
@@ -3,8 +3,7 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import BotFlowEditor from '@/components/BotFlowEditor'
 
-export default async function EditBotPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
+export default async function EditBotPage({ params }: { params: { id: string } }) {
   const supabase = createServerComponentClient({ cookies })
   const {
     data: { session },
@@ -16,14 +15,14 @@ export default async function EditBotPage({ params }: { params: Promise<{ id: st
   const { data: bot } = await supabase
     .from('bots')
     .select('*')
-    .eq('id', id)
+    .eq('id', params.id)
     .single()
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">{bot?.name}</h1>
       <BotFlowEditor
-        botId={id}
+        botId={params.id}
         initialNodes={bot?.flow_json?.nodes || []}
         initialEdges={bot?.flow_json?.edges || []}
       />


### PR DESCRIPTION
## Summary
- standardize `params` usage in bot API routes and dashboard page

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684a06fcb63083248dfaae794210f26f