### PR TITLE
Remove unused router import

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 'use client'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import logo from '../assets/atendor-logo.svg'
 
 export default function Sidebar() {


### PR DESCRIPTION
## Summary
- clean up Sidebar by removing unused `useRouter` import

## Testing
- `pnpm install`
- `pnpm lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684a06ffc9e0832481efb5f87ba5a9a2