### PR TITLE
Add visual flow builder

### DIFF
--- a/components/VisualBuilder.tsx
+++ b/components/VisualBuilder.tsx
@@ -1,0 +1,152 @@
+'use client'
+import React, { useCallback, useEffect } from 'react'
+import ReactFlow, {
+  addEdge,
+  Background,
+  Controls,
+  MiniMap,
+  useReactFlow,
+  useNodesState,
+  useEdgesState,
+  Connection,
+  Node,
+  Edge,
+} from 'react-flow-renderer'
+import PromptNode from './nodes/PromptNode'
+import ToolNode from './nodes/ToolNode'
+import OutputNode from './nodes/OutputNode'
+import { useFlowData } from '@/hooks/useFlowData'
+import type { NodeData } from '@/types'
+
+const nodeTypes = {
+  prompt: PromptNode,
+  tool: ToolNode,
+  output: OutputNode,
+}
+
+export default function VisualBuilder({ flowName }: { flowName: string }) {
+  const { nodes: initialNodes, edges: initialEdges, setNodes, setEdges, save } =
+    useFlowData(flowName)
+
+  const [nodes, _setNodes, onNodesChange] = useNodesState<Node<NodeData>[]>([])
+  const [edges, _setEdges, onEdgesChange] = useEdgesState<Edge[]>([])
+  const reactFlowInstance = useReactFlow()
+
+  useEffect(() => {
+    _setNodes(initialNodes)
+    _setEdges(initialEdges)
+  }, [initialNodes, initialEdges, _setNodes, _setEdges])
+
+  const isValid = (connection: Connection) => {
+    const source = nodes.find((n) => n.id === connection.source)
+    const target = nodes.find((n) => n.id === connection.target)
+    if (!source || !target) return false
+    if (source.type === 'prompt' && target.type === 'tool') return true
+    if (source.type === 'tool' && target.type === 'output') return true
+    return false
+  }
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      if (isValid(connection)) {
+        _setEdges((eds) =>
+          addEdge({ ...connection, type: 'smoothstep' }, eds)
+        )
+      }
+    },
+    [nodes, _setEdges]
+  )
+
+  const onDragStart = (event: React.DragEvent, nodeType: string) => {
+    event.dataTransfer.setData('application/reactflow', nodeType)
+    event.dataTransfer.effectAllowed = 'move'
+  }
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault()
+      const type = event.dataTransfer.getData('application/reactflow')
+      if (!type) return
+      const position = reactFlowInstance.project({
+        x: event.clientX - 250,
+        y: event.clientY,
+      })
+      const newNode: Node<NodeData> = {
+        id: `${+new Date()}`,
+        type,
+        position,
+        data: {},
+      }
+      _setNodes((nds) => nds.concat(newNode))
+    },
+    [reactFlowInstance, _setNodes]
+  )
+
+  const onDragOver = (event: React.DragEvent) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+  }
+
+  const handleSave = async () => {
+    await save(nodes, edges)
+  }
+
+  useEffect(() => {
+    setNodes(nodes)
+  }, [nodes, setNodes])
+
+  useEffect(() => {
+    setEdges(edges)
+  }, [edges, setEdges])
+
+  return (
+    <div className="flex h-[500px]">
+      <div className="w-40 bg-slate-100 p-2 space-y-2 text-sm">
+        <div
+          className="p-2 bg-white rounded shadow cursor-grab"
+          onDragStart={(e) => onDragStart(e, 'prompt')}
+          draggable
+        >
+          Prompt
+        </div>
+        <div
+          className="p-2 bg-white rounded shadow cursor-grab"
+          onDragStart={(e) => onDragStart(e, 'tool')}
+          draggable
+        >
+          Tool
+        </div>
+        <div
+          className="p-2 bg-white rounded shadow cursor-grab"
+          onDragStart={(e) => onDragStart(e, 'output')}
+          draggable
+        >
+          Output
+        </div>
+      </div>
+      <div className="flex-1 relative">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          nodeTypes={nodeTypes}
+          fitView
+        >
+          <MiniMap />
+          <Controls />
+          <Background />
+        </ReactFlow>
+        <button
+          onClick={handleSave}
+          className="absolute bottom-4 right-4 bg-black text-white px-4 py-2 rounded"
+        >
+          Save Flow
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/nodes/OutputNode.tsx
+++ b/components/nodes/OutputNode.tsx
@@ -1,0 +1,11 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+export default function OutputNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-sm">
+      {data.output || 'Output'}
+    </div>
+  )
+}

--- a/components/nodes/PromptNode.tsx
+++ b/components/nodes/PromptNode.tsx
@@ -1,0 +1,19 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+export default function PromptNode({ data }: NodeProps<NodeData>) {
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (data) data.prompt = e.target.value
+  }
+  return (
+    <div className="p-2 bg-white rounded shadow w-48">
+      <textarea
+        className="w-full border rounded p-1"
+        placeholder="Prompt..."
+        value={data.prompt}
+        onChange={onChange}
+      />
+    </div>
+  )
+}

--- a/components/nodes/ToolNode.tsx
+++ b/components/nodes/ToolNode.tsx
@@ -1,0 +1,27 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+const tools = ['WhatsApp', 'Search', 'Email']
+
+export default function ToolNode({ data }: NodeProps<NodeData>) {
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (data) data.tool = e.target.value
+  }
+  return (
+    <div className="p-2 bg-white rounded shadow w-40">
+      <select
+        className="w-full border rounded p-1"
+        value={data.tool}
+        onChange={onChange}
+      >
+        <option value="">Select tool</option>
+        {tools.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/hooks/useFlowData.ts
+++ b/hooks/useFlowData.ts
@@ -1,0 +1,47 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import type { FlowType } from '@/types'
+import type { Node, Edge } from 'react-flow-renderer'
+
+export function useFlowData(flowName: string) {
+  const [nodes, setNodes] = useState<Node[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [flowId, setFlowId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchFlow = async () => {
+      const { data } = await supabase
+        .from('flows')
+        .select('*')
+        .eq('flowName', flowName)
+        .single()
+      if (data) {
+        setFlowId(data.id)
+        setNodes(data.nodes || [])
+        setEdges(data.edges || [])
+      }
+    }
+    fetchFlow()
+  }, [flowName])
+
+  const save = async (newNodes: Node[], newEdges: Edge[]) => {
+    const payload: Partial<FlowType> = {
+      flowName,
+      nodes: newNodes,
+      edges: newEdges,
+    }
+    if (flowId) {
+      await supabase.from('flows').update(payload).eq('id', flowId)
+    } else {
+      const { data } = await supabase
+        .from('flows')
+        .insert(payload)
+        .select()
+        .single()
+      if (data) setFlowId(data.id)
+    }
+  }
+
+  return { nodes, edges, setNodes, setEdges, save }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,13 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  ''
+
+const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_PUBLIC ||
+  ''
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,17 @@
+import type { Edge, Node } from 'react-flow-renderer'
+
+export type NodeData = {
+  label?: string
+  prompt?: string
+  tool?: string
+  output?: string
+}
+
+export type FlowType = {
+  id?: string
+  flowName: string
+  user_id?: string
+  created_at?: string
+  nodes: Node<NodeData>[]
+  edges: Edge[]
+}


### PR DESCRIPTION
## Summary
- add a new VisualBuilder component with drag/drop React Flow canvas
- implement PromptNode, ToolNode and OutputNode
- include a client supabase helper and basic flow management hook
- define shared flow types

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684a0d9dbbf483249d58ed02f5aec8fa