### PR TITLE
Fix VisualBuilder node updates

### DIFF
--- a/components/VisualBuilder.tsx
+++ b/components/VisualBuilder.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useCallback, useEffect } from 'react'
+import { nanoid } from 'nanoid'
 import ReactFlow, {
   addEdge,
   Background,
@@ -28,8 +29,8 @@ export default function VisualBuilder({ flowName }: { flowName: string }) {
   const { nodes: initialNodes, edges: initialEdges, setNodes, setEdges, save } =
     useFlowData(flowName)
 
-  const [nodes, _setNodes, onNodesChange] = useNodesState<Node<NodeData>[]>([])
-  const [edges, _setEdges, onEdgesChange] = useEdgesState<Edge[]>([])
+  const [nodes, _setNodes, onNodesChange] = useNodesState<NodeData>([])
+  const [edges, _setEdges, onEdgesChange] = useEdgesState([])
   const reactFlowInstance = useReactFlow()
 
   useEffect(() => {
@@ -72,12 +73,12 @@ export default function VisualBuilder({ flowName }: { flowName: string }) {
         y: event.clientY,
       })
       const newNode: Node<NodeData> = {
-        id: `${+new Date()}`,
+        id: nanoid(),
         type,
         position,
         data: {},
       }
-      _setNodes((nds) => nds.concat(newNode))
+      _setNodes((nds) => [...nds, newNode])
     },
     [reactFlowInstance, _setNodes]
   )

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.50.0",
     "lucide-react": "^0.513.0",
     "magic-ui": "^0.1.0",
+    "nanoid": "^5.1.5",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-flow-renderer": "^10.3.17",
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "ui": "git+https://github.com/shadcn/ui.git"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       magic-ui:
         specifier: ^0.1.0
         version: 0.1.0
+      nanoid:
+        specifier: ^5.1.5
+        version: 5.1.5
       next:
         specifier: 15.3.3
         version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3240,6 +3243,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   napi-postinstall@0.2.4:
     resolution: {integrity: sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -4864,7 +4872,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.19.0)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -6308,7 +6316,7 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.19.0)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)
@@ -6744,7 +6752,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -6783,7 +6791,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6798,7 +6806,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7864,6 +7872,8 @@ snapshots:
   nan@2.22.2: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.5: {}
 
   napi-postinstall@0.2.4: {}
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,7 +1,6 @@
 import type { Edge, Node } from 'react-flow-renderer'
 
 export type NodeData = {
-  label?: string
   prompt?: string
   tool?: string
   output?: string


### PR DESCRIPTION
## Summary
- generate IDs with `nanoid`
- correct generics for `useNodesState` and `useEdgesState`
- use spread operator when appending nodes
- slim down `NodeData` type
- add `nanoid` dependency

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684a12c79f988324b9487a1ca6d3464e