### PR TITLE
Add file upload UI and embedding pipeline

### DIFF
--- a/app/api/embed/route.ts
+++ b/app/api/embed/route.ts
@@ -1,0 +1,52 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { Configuration, OpenAIApi } from 'openai'
+
+export async function POST(request: Request) {
+  const { botId, fileId } = await request.json()
+  const supabase = createRouteHandlerClient(
+    { cookies },
+    {
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data: bot } = await supabase
+    .from('bots')
+    .select('user_id')
+    .eq('id', botId)
+    .single()
+  if (!bot || bot.user_id !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  const { data: file } = await supabase
+    .from('files')
+    .select('*')
+    .eq('id', fileId)
+    .single()
+  if (!file) {
+    return NextResponse.json({ error: 'File not found' }, { status: 404 })
+  }
+  const { data: download, error: downloadError } = await supabase.storage
+    .from('bot-files')
+    .download(`${botId}/${file.file_name}`)
+  if (downloadError || !download) {
+    return NextResponse.json({ error: downloadError?.message }, { status: 500 })
+  }
+  const text = await download.text()
+  const openai = new OpenAIApi(new Configuration({ apiKey: process.env.OPENAI_KEY }))
+  const embedding = await openai
+    .createEmbedding({ model: 'text-embedding-ada-002', input: text })
+    .then((res) => res.data.data[0].embedding)
+  await supabase.from('file_vectors').insert({ file_id: fileId, embedding })
+  await supabase.from('files').update({ embedded: true }).eq('id', fileId)
+  return NextResponse.json({ success: true })
+}

--- a/app/dashboard/bots/[id]/builder/page.tsx
+++ b/app/dashboard/bots/[id]/builder/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { UploadArea } from '@/components/builder/UploadArea'
+import { FileList } from '@/components/builder/FileList'
+import { useUser } from '@/hooks/useUser'
+
+export default function BotBuilderPage({ params }: { params: { id: string } }) {
+  const { isLoading } = useUser()
+  if (isLoading) return <p className="p-4">Loading...</p>
+  const { id } = params
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Bot Builder</h1>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Files</h2>
+        <UploadArea botId={id} />
+        <FileList />
+      </section>
+    </div>
+  )
+}

--- a/components/builder/FileList.tsx
+++ b/components/builder/FileList.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { FileText, Image as ImageIcon, File as GenericFile } from 'lucide-react'
+import { useBotBuilderStore } from '@/store/botBuilderStore'
+import type { UploadedFile } from '@/store/botBuilderStore'
+
+const iconFor = (type: UploadedFile['type']) => {
+  switch (type) {
+    case 'pdf':
+      return <FileText className="w-4 h-4" />
+    case 'image':
+      return <ImageIcon className="w-4 h-4" />
+    default:
+      return <GenericFile className="w-4 h-4" />
+  }
+}
+
+export function FileList() {
+  const files = useBotBuilderStore((s) => s.files)
+  if (files.length === 0) {
+    return <p className="text-sm text-gray-500">No files uploaded.</p>
+  }
+  return (
+    <ul className="space-y-2">
+      {files.map((f) => (
+        <li
+          key={f.id}
+          className="flex items-center justify-between border p-2 rounded"
+        >
+          <div className="flex items-center space-x-2">
+            {iconFor(f.type)}
+            <span>{f.name}</span>
+            <span className="text-xs text-gray-500">
+              {(f.size / 1024 / 1024).toFixed(2)} MB
+            </span>
+          </div>
+          <span
+            className={`text-xs px-2 py-1 rounded ${f.embedded ? 'bg-green-200 text-green-800' : 'bg-yellow-200 text-yellow-800'}`}
+          >
+            {f.embedded ? 'Embedded' : 'Pending'}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/components/builder/UploadArea.tsx
+++ b/components/builder/UploadArea.tsx
@@ -1,0 +1,65 @@
+'use client'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { FilesCrud, FILE_TYPE_EXTENSIONS } from '@/lib/actions/files'
+import { useBotBuilderStore } from '@/store/botBuilderStore'
+
+export function UploadArea({ botId }: { botId: string }) {
+  const [loading, setLoading] = useState(false)
+  const addFile = useBotBuilderStore((s) => s.addFile)
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (!files) return
+    const allowed = Object.values(FILE_TYPE_EXTENSIONS).flat()
+    const crud = new FilesCrud()
+    for (const file of Array.from(files)) {
+      const ext = `.${file.name.split('.').pop()}`.toLowerCase()
+      if (!allowed.includes(ext)) {
+        toast.error(`Unsupported file type: ${ext}`)
+        continue
+      }
+      setLoading(true)
+      try {
+        const record = await crud.uploadAndCreate({ botId, file })
+        addFile({
+          id: record.id!,
+          name: record.file_name,
+          type: record.file_type,
+          size: file.size,
+          url: record.url,
+          embedded: record.embedded,
+        })
+        await fetch('/api/embed', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ botId, fileId: record.id }),
+        })
+          .then(() =>
+            useBotBuilderStore.getState().updateFileStatus(
+              record.id!,
+              'embedded'
+            )
+          )
+        toast.success(`${file.name} uploaded`)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Upload failed'
+        toast.error(message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    e.target.value = ''
+  }
+  return (
+    <div className="space-y-2">
+      <input
+        type="file"
+        multiple
+        onChange={handleChange}
+        disabled={loading}
+        className="file-input file-input-bordered w-full"
+      />
+      {loading && <p className="text-sm">Uploading...</p>}
+    </div>
+  )
+}

--- a/lib/actions/files.ts
+++ b/lib/actions/files.ts
@@ -1,0 +1,85 @@
+import { cookies } from 'next/headers'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import type { BotFile, FileType } from '@/types'
+
+export const FILE_TYPE_EXTENSIONS: Record<FileType, string[]> = {
+  pdf: ['.pdf'],
+  text: ['.txt', '.md', '.csv'],
+  image: ['.png', '.jpg', '.jpeg', '.gif', '.webp'],
+}
+
+const options = {
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+  supabaseKey:
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+}
+
+export function getFileTypeFromExtension(ext: string): FileType | null {
+  const lower = ext.toLowerCase()
+  for (const [type, extensions] of Object.entries(FILE_TYPE_EXTENSIONS) as [
+    FileType,
+    string[]
+  ][]) {
+    if (extensions.includes(lower)) return type
+  }
+  return null
+}
+
+export class FilesCrud {
+  async create(
+    botId: string,
+    file: { name: string; url: string; size_mb: number }
+  ) {
+    const extension = `.${file.name.split('.').pop() || ''}`.toLowerCase()
+    const file_type = getFileTypeFromExtension(extension)
+    if (!file_type) {
+      throw new Error(`Unsupported extension ${extension}`)
+    }
+    const supabase = createServerComponentClient({ cookies }, options)
+    const { data, error } = await supabase
+      .from('files')
+      .insert({
+        bot_id: botId,
+        file_name: file.name,
+        file_type,
+        url: file.url,
+        size_mb: file.size_mb,
+        embedded: false,
+      })
+      .select()
+      .single()
+    if (error) throw new Error(error.message)
+    return data as BotFile
+  }
+
+  async uploadAndCreate({
+    botId,
+    file,
+  }: {
+    botId: string
+    file: File
+  }) {
+    const extension = `.${file.name.split('.').pop() || ''}`.toLowerCase()
+    if (
+      !Object.values(FILE_TYPE_EXTENSIONS)
+        .flat()
+        .includes(extension)
+    ) {
+      throw new Error(`Unsupported extension ${extension}`)
+    }
+    const supabase = createServerComponentClient({ cookies }, options)
+    const { data, error } = await supabase.storage
+      .from('bot-files')
+      .upload(`${botId}/${file.name}`, file, { upsert: true })
+    if (error) throw new Error(error.message)
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from('bot-files').getPublicUrl(`${botId}/${file.name}`)
+    const record = await this.create(botId, {
+      name: file.name,
+      url: publicUrl,
+      size_mb: file.size / 1024 / 1024,
+    })
+    return record
+  }
+}

--- a/store/botBuilderStore.ts
+++ b/store/botBuilderStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import type { FileType } from '@/types'
+
+export type UploadedFile = {
+  id: string
+  name: string
+  type: FileType
+  size: number
+  url: string
+  embedded: boolean
+}
+
+interface BotBuilderState {
+  files: UploadedFile[]
+  addFile: (file: UploadedFile) => void
+  removeFile: (fileId: string) => void
+  updateFileStatus: (fileId: string, status: 'pending' | 'embedded') => void
+}
+
+export const useBotBuilderStore = create<BotBuilderState>((set) => ({
+  files: [],
+  addFile: (file) => set((state) => ({ files: [...state.files, file] })),
+  removeFile: (fileId) =>
+    set((state) => ({ files: state.files.filter((f) => f.id !== fileId) })),
+  updateFileStatus: (fileId, status) =>
+    set((state) => ({
+      files: state.files.map((f) =>
+        f.id === fileId ? { ...f, embedded: status === 'embedded' } : f
+      ),
+    })),
+}))

--- a/types/index.ts
+++ b/types/index.ts
@@ -22,3 +22,15 @@ export type Bot = {
   user_id?: string
   created_at?: string
 }
+
+export type FileType = 'pdf' | 'text' | 'image'
+
+export type BotFile = {
+  id?: string
+  bot_id: string
+  file_name: string
+  file_type: FileType
+  url: string
+  size_mb: number
+  embedded: boolean
+}


### PR DESCRIPTION
## Summary
- integrate Supabase storage helpers with `uploadAndCreate`
- create bot builder page with file management section
- add Zustand store for uploaded files
- implement UploadArea and FileList components
- provide embed API route to process files

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684abb5c3cc48324bb310d45fd3069ac