### PR TITLE
Implement pricing page and plan-based chat model

### DIFF
--- a/app/api/bots/route.ts
+++ b/app/api/bots/route.ts
@@ -50,6 +50,8 @@ export async function POST(request: Request) {
     .insert({
       name,
       description,
+      plan_level: 'starter',
+      llm_profile: 'standard',
       user_id: session.user.id,
       flow_json: { nodes: [], edges: [] },
     })

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,76 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+type PlanLevel = 'starter' | 'pro' | 'enterprise'
+
+type ChatMessage = {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+async function groqChat(model: string, messages: ChatMessage[]) {
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+    },
+    body: JSON.stringify({ model, messages }),
+  })
+  return res.json()
+}
+
+async function openrouterChat(model: string, messages: ChatMessage[]) {
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+      'HTTP-Referer': process.env.OPENROUTER_REFERER || '',
+      'X-Title': 'Atendor',
+    },
+    body: JSON.stringify({ model, messages }),
+  })
+  return res.json()
+}
+
+async function selectModelByPlan(plan: PlanLevel, messages: ChatMessage[]) {
+  switch (plan) {
+    case 'starter':
+      return groqChat('mistral-7b', messages)
+    case 'pro':
+      return openrouterChat('gpt-4-turbo', messages)
+    case 'enterprise':
+      return openrouterChat('claude-3-opus', messages)
+    default:
+      return groqChat('mistral-7b', messages)
+  }
+}
+
+export async function POST(request: Request) {
+  const { botId, messages } = await request.json()
+  const supabase = createRouteHandlerClient(
+    { cookies },
+    {
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!,
+      supabaseKey:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_PUBLIC!,
+    }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data: bot } = await supabase
+    .from('bots')
+    .select('plan_level')
+    .eq('id', botId)
+    .eq('user_id', session.user.id)
+    .single()
+  const plan = (bot?.plan_level ?? 'starter') as PlanLevel
+  const aiResponse = await selectModelByPlan(plan, messages)
+  return NextResponse.json(aiResponse)
+}

--- a/app/dashboard/bots/[id]/builder/page.tsx
+++ b/app/dashboard/bots/[id]/builder/page.tsx
@@ -10,6 +10,12 @@ export default function BotBuilderPage({ params }: { params: { id: string } }) {
   return (
     <div className="p-4 space-y-6">
       <h1 className="text-2xl font-bold">Bot Builder</h1>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Settings</h2>
+        <span className="text-sm text-muted-foreground">
+          Your bot is powered by: <strong>Advanced AI</strong> (based on your plan)
+        </span>
+      </section>
       <section className="space-y-4">
         <h2 className="text-xl font-semibold">Files</h2>
         <UploadArea botId={id} />

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,55 @@
+import PublicHeader from '@/components/PublicHeader'
+import PublicFooter from '@/components/PublicFooter'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Pricing – Atendor',
+  description: 'Choose the plan that fits your needs.'
+}
+
+export default function PricingPage() {
+  return (
+    <main className="space-y-12">
+      <PublicHeader />
+      <section className="px-4 py-16 mx-auto max-w-5xl space-y-8">
+        <h1 className="text-3xl font-semibold text-center">Pricing</h1>
+        <div className="grid gap-8 md:grid-cols-3">
+          <div className="card border p-6 space-y-4">
+            <h2 className="text-xl font-bold">Starter</h2>
+            <p className="text-2xl">€9 <span className="text-base">/ mes</span></p>
+            <ul className="space-y-1 text-sm">
+              <li>1 bot</li>
+              <li>3 files</li>
+              <li>Fast responses</li>
+            </ul>
+            <button className="btn btn-primary w-full">Choose Starter</button>
+          </div>
+          <div className="card border p-6 space-y-4">
+            <h2 className="text-xl font-bold">Pro</h2>
+            <p className="text-2xl">€29 <span className="text-base">/ mes</span></p>
+            <ul className="space-y-1 text-sm">
+              <li>5 bots</li>
+              <li>20 files</li>
+              <li>Advanced answers</li>
+            </ul>
+            <button className="btn btn-primary w-full">Choose Pro</button>
+          </div>
+          <div className="card border p-6 space-y-4">
+            <h2 className="text-xl font-bold">Enterprise</h2>
+            <p className="text-2xl">Custom</p>
+            <ul className="space-y-1 text-sm">
+              <li>Unlimited bots</li>
+              <li>Team collaboration</li>
+              <li>Custom integrations</li>
+              <li>Priority support</li>
+            </ul>
+            <Link href="mailto:contact@example.com" className="btn btn-primary w-full">
+              Contact Us
+            </Link>
+          </div>
+        </div>
+      </section>
+      <PublicFooter />
+    </main>
+  )
+}

--- a/components/PublicHeader.tsx
+++ b/components/PublicHeader.tsx
@@ -18,6 +18,7 @@ export default function PublicHeader() {
         <nav className="hidden md:flex space-x-6" aria-label="Main">
           <Link href="#" className="hover:underline">Home</Link>
           <Link href="#features" className="hover:underline">Features</Link>
+          <Link href="/pricing" className="text-sm font-medium hover:underline">Pricing</Link>
           <Link href="#contact" className="hover:underline">Contact</Link>
           <Link href="/login" className="font-medium hover:underline">Login</Link>
         </nav>
@@ -32,6 +33,7 @@ export default function PublicHeader() {
         <nav className="md:hidden px-4 pb-4 space-y-2" aria-label="Mobile">
           <Link href="/" className="block" onClick={() => setOpen(false)}>Home</Link>
           <Link href="#features" className="block" onClick={() => setOpen(false)}>Features</Link>
+          <Link href="/pricing" className="block" onClick={() => setOpen(false)}>Pricing</Link>
           <Link href="#contact" className="block" onClick={() => setOpen(false)}>Contact</Link>
           <Link href="/login" className="block" onClick={() => setOpen(false)}>Login</Link>
         </nav>

--- a/lib/actions/bots.ts
+++ b/lib/actions/bots.ts
@@ -12,7 +12,9 @@ export async function getBotById(id: string, userId: string) {
   const supabase = createServerComponentClient({ cookies }, options)
   const { data, error } = await supabase
     .from('bots')
-    .select('id, name, description, user_id, created_at')
+    .select(
+      'id, name, description, plan_level, llm_profile, user_id, created_at'
+    )
     .eq('id', id)
     .eq('user_id', userId)
     .single()

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,6 +19,8 @@ export type Bot = {
   id?: string
   name: string
   description: string
+  plan_level?: 'starter' | 'pro' | 'enterprise'
+  llm_profile?: 'standard' | 'advanced' | 'premium'
   user_id?: string
   created_at?: string
 }


### PR DESCRIPTION
## Summary
- store plan info for bots
- route chat API requests to different models based on plan
- add pricing page with three SaaS tiers
- show plan-based AI message in bot builder
- link Pricing from public header

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ade4872fc8324b563f51d2ac13a92