### PR TITLE
Implement visual bot builder

### DIFF
--- a/app/dashboard/bots/[id]/builder/page.tsx
+++ b/app/dashboard/bots/[id]/builder/page.tsx
@@ -2,6 +2,7 @@
 import { UploadArea } from '@/components/builder/UploadArea'
 import { FileList } from '@/components/builder/FileList'
 import { useUser } from '@/hooks/useUser'
+import BotFlowBuilder from '@/components/BotFlowBuilder'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function BotBuilderPage({ params }: { params: any }) {
@@ -11,6 +12,7 @@ export default function BotBuilderPage({ params }: { params: any }) {
   return (
     <div className="p-4 space-y-6">
       <h1 className="text-2xl font-bold">Bot Builder</h1>
+      <BotFlowBuilder botId={id} />
       <section className="space-y-2">
         <h2 className="text-xl font-semibold">Settings</h2>
         <span className="text-sm text-muted-foreground">

--- a/components/BotFlowBuilder.tsx
+++ b/components/BotFlowBuilder.tsx
@@ -1,0 +1,335 @@
+'use client'
+import React, { useCallback, useEffect, useState } from 'react'
+import ReactFlow, {
+  addEdge,
+  Background,
+  Controls,
+  MiniMap,
+  applyEdgeChanges,
+  applyNodeChanges,
+  type Connection,
+  type Edge,
+  type Node,
+  EdgeChange,
+  NodeChange,
+} from 'react-flow-renderer'
+import { nanoid } from 'nanoid'
+import { useFlowStore } from '@/store/flowStore'
+import type { NodeData } from '@/types'
+import StartNode from './nodes/StartNode'
+import SendMessageNode from './nodes/SendMessageNode'
+import WaitNode from './nodes/WaitNode'
+import ReceiveInputNode from './nodes/ReceiveInputNode'
+import FileLookupNode from './nodes/FileLookupNode'
+import HttpRequestNode from './nodes/HttpRequestNode'
+import DecisionNode from './nodes/DecisionNode'
+import EndNode from './nodes/EndNode'
+
+const nodeTypes = {
+  start: StartNode,
+  send: SendMessageNode,
+  wait: WaitNode,
+  input: ReceiveInputNode,
+  file: FileLookupNode,
+  http: HttpRequestNode,
+  decision: DecisionNode,
+  end: EndNode,
+}
+
+type Props = { botId: string }
+
+export default function BotFlowBuilder({ botId }: Props) {
+  const [rfNodes, setRfNodes] = useState<Node<NodeData>[]>([])
+  const [rfEdges, setRfEdges] = useState<Edge[]>([])
+  const store = useFlowStore()
+
+  useEffect(() => {
+    store.load(botId)
+  }, [botId, store])
+
+  useEffect(() => {
+    setRfNodes(store.nodes)
+  }, [store.nodes, store])
+
+  useEffect(() => {
+    setRfEdges(store.edges)
+  }, [store.edges, store])
+
+  useEffect(() => {
+    store.setNodes(rfNodes)
+  }, [rfNodes, store])
+
+  useEffect(() => {
+    store.setEdges(rfEdges)
+  }, [rfEdges, store])
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) =>
+      setRfNodes((nds) => applyNodeChanges(changes, nds)),
+    []
+  )
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) =>
+      setRfEdges((eds) => applyEdgeChanges(changes, eds)),
+    []
+  )
+  const onConnect = useCallback(
+    (connection: Connection) =>
+      setRfEdges((eds) => addEdge({ ...connection, type: 'smoothstep' }, eds)),
+    []
+  )
+
+  const onDragStart = (event: React.DragEvent, nodeType: string) => {
+    event.dataTransfer.setData('application/reactflow', nodeType)
+    event.dataTransfer.effectAllowed = 'move'
+  }
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault()
+      const type = event.dataTransfer.getData('application/reactflow')
+      if (!type) return
+      if (type === 'start' && rfNodes.some((n) => n.type === 'start')) {
+        alert('Only one start node allowed')
+        return
+      }
+      const position = (event.target as HTMLElement).getBoundingClientRect()
+      const newNode: Node<NodeData> = {
+        id: nanoid(),
+        type,
+        position: { x: event.clientX - position.left, y: event.clientY - position.top },
+        data: {},
+      }
+      setRfNodes((nds) => [...nds, newNode])
+    },
+    [rfNodes]
+  )
+
+  const onDragOver = (event: React.DragEvent) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+  }
+
+  const save = async () => {
+    await store.save(botId)
+    alert('Flow saved')
+  }
+
+  const selectNode = (_: React.MouseEvent, node: Node<NodeData>) => {
+    store.setSelected(node)
+  }
+
+  const deleteSelected = () => {
+    const node = store.selected
+    if (!node) return
+    setRfNodes((nds) => nds.filter((n) => n.id !== node.id))
+    setRfEdges((eds) => eds.filter((e) => e.source !== node.id && e.target !== node.id))
+    store.setSelected(null)
+  }
+
+  // Templates
+  const [showTemplates, setShowTemplates] = useState(false)
+  const applyTemplate = (name: string) => {
+    const base = [
+      { id: nanoid(), type: 'start', position: { x: 0, y: 0 }, data: {} },
+      { id: nanoid(), type: 'end', position: { x: 600, y: 0 }, data: {} },
+    ]
+    let nodes: Node<NodeData>[] = []
+    let edges: Edge[] = []
+    if (name === 'faq') {
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'input', position: { x: 150, y: 0 }, data: {} },
+        { id: nanoid(), type: 'file', position: { x: 300, y: 0 }, data: {} },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: {} },
+        base[1],
+      ]
+    } else if (name === 'lead') {
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: "What's your name?" } },
+        { id: nanoid(), type: 'input', position: { x: 300, y: 0 }, data: {} },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: "What's your email?" } },
+        { id: nanoid(), type: 'input', position: { x: 600, y: 0 }, data: {} },
+        base[1],
+      ]
+    } else if (name === 'wa') {
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'Hello! Welcome 👋' } },
+        { id: nanoid(), type: 'wait', position: { x: 300, y: 0 }, data: { delay: 2 } },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: 'How can I help you today?' } },
+        base[1],
+      ]
+    }
+    // edges sequential
+    edges = nodes.slice(0, -1).map((n, i) => ({
+      id: nanoid(),
+      source: n.id,
+      target: nodes[i + 1].id,
+      type: 'smoothstep',
+    }))
+    setRfNodes(nodes)
+    setRfEdges(edges)
+    setShowTemplates(false)
+  }
+
+  const updateNodeData = (field: keyof NodeData, value: string | number) => {
+    const node = store.selected
+    if (!node) return
+    setRfNodes((nds) =>
+      nds.map((n) =>
+        n.id === node.id ? { ...n, data: { ...n.data, [field]: value } } : n
+      )
+    )
+  }
+
+  return (
+    <div className="flex h-[600px] border rounded overflow-hidden">
+      <div className="w-40 bg-slate-100 p-2 space-y-2" aria-label="Node palette">
+        {[
+          ['start', 'Start'],
+          ['send', 'Send Message'],
+          ['wait', 'Wait'],
+          ['input', 'Receive Input'],
+          ['file', 'File Lookup'],
+          ['http', 'HTTP Request'],
+          ['decision', 'Decision'],
+          ['end', 'End'],
+        ].map(([type, label]) => (
+          <div
+            key={type}
+            role="button"
+            tabIndex={0}
+            className="p-2 bg-white rounded shadow cursor-grab"
+            onDragStart={(e) => onDragStart(e, type)}
+            draggable
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+      <div className="flex-1 relative" onDrop={onDrop} onDragOver={onDragOver}>
+        <ReactFlow
+          nodes={rfNodes}
+          edges={rfEdges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          nodeTypes={nodeTypes}
+          onNodeClick={selectNode}
+          fitView
+        >
+          <MiniMap />
+          <Controls />
+          <Background />
+        </ReactFlow>
+        <button
+          onClick={() => setShowTemplates(true)}
+          className="absolute top-2 left-1/2 -translate-x-1/2 bg-white border px-3 py-1 rounded text-sm"
+        >
+          + Templates
+        </button>
+        <div className="absolute bottom-2 right-2 space-x-2">
+          <button
+            onClick={save}
+            className="bg-black text-white px-3 py-1 rounded text-sm"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+      <aside className="w-60 border-l p-4 space-y-2 text-sm">
+        <div className="text-xs text-gray-500" aria-live="polite">
+          Upgrade your plan to unlock more AI power
+        </div>
+        {store.selected && (
+          <div>
+            <h2 className="font-semibold mb-2">Node Settings</h2>
+            {['send', 'start', 'end'].includes(store.selected.type ?? '') && (
+              <div className="mb-2">
+                <label className="block mb-1" htmlFor="label">Label</label>
+                <input
+                  id="label"
+                  className="w-full border p-1"
+                  value={store.selected.data.label || ''}
+                  onChange={(e) => updateNodeData('label', e.target.value)}
+                />
+              </div>
+            )}
+            {store.selected.type === 'send' && (
+              <div className="mb-2">
+                <label className="block mb-1" htmlFor="message">Message</label>
+                <textarea
+                  id="message"
+                  className="w-full border p-1"
+                  value={store.selected.data.message || ''}
+                  onChange={(e) => updateNodeData('message', e.target.value)}
+                />
+              </div>
+            )}
+            {store.selected.type === 'wait' && (
+              <div className="mb-2">
+                <label className="block mb-1" htmlFor="delay">Delay (s)</label>
+                <input
+                  id="delay"
+                  type="number"
+                  className="w-full border p-1"
+                  value={store.selected.data.delay ?? 1}
+                  onChange={(e) => updateNodeData('delay', Number(e.target.value))}
+                />
+              </div>
+            )}
+            {store.selected.type === 'http' && (
+              <div className="mb-2">
+                <label className="block mb-1" htmlFor="url">URL</label>
+                <input
+                  id="url"
+                  className="w-full border p-1"
+                  value={store.selected.data.url || ''}
+                  onChange={(e) => updateNodeData('url', e.target.value)}
+                />
+              </div>
+            )}
+            {store.selected.type === 'decision' && (
+              <div className="mb-2">
+                <label className="block mb-1" htmlFor="condition">Condition</label>
+                <input
+                  id="condition"
+                  className="w-full border p-1"
+                  value={store.selected.data.condition || ''}
+                  onChange={(e) => updateNodeData('condition', e.target.value)}
+                />
+              </div>
+            )}
+            <button
+              onClick={deleteSelected}
+              className="mt-2 bg-red-500 text-white px-2 py-1 rounded"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </aside>
+      {showTemplates && (
+        <div className="absolute inset-0 bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true">
+          <div className="bg-white p-4 rounded space-y-4 w-72">
+            <h2 className="font-semibold text-center">Select Template</h2>
+            <button className="w-full border p-2" onClick={() => applyTemplate('faq')}>
+              FAQ Bot
+            </button>
+            <button className="w-full border p-2" onClick={() => applyTemplate('lead')}>
+              Lead Collector Bot
+            </button>
+            <button className="w-full border p-2" onClick={() => applyTemplate('wa')}>
+              WhatsApp Greeter Bot
+            </button>
+            <button className="w-full border p-2" onClick={() => setShowTemplates(false)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/nodes/DecisionNode.tsx
+++ b/components/nodes/DecisionNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function DecisionNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-center text-sm">
+      {data.condition || 'Decision'}
+    </div>
+  )
+}

--- a/components/nodes/EndNode.tsx
+++ b/components/nodes/EndNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function EndNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-center text-sm">
+      {data.label || 'End'}
+    </div>
+  )
+}

--- a/components/nodes/FileLookupNode.tsx
+++ b/components/nodes/FileLookupNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function FileLookupNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-center text-sm">
+      {data.label || 'File Lookup'}
+    </div>
+  )
+}

--- a/components/nodes/HttpRequestNode.tsx
+++ b/components/nodes/HttpRequestNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function HttpRequestNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-center text-sm">
+      {data.url || 'HTTP Request'}
+    </div>
+  )
+}

--- a/components/nodes/ReceiveInputNode.tsx
+++ b/components/nodes/ReceiveInputNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function ReceiveInputNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-center text-sm">
+      {data.label || 'Receive Input'}
+    </div>
+  )
+}

--- a/components/nodes/SendMessageNode.tsx
+++ b/components/nodes/SendMessageNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function SendMessageNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-sm">
+      {data.message || 'Send Message'}
+    </div>
+  )
+}

--- a/components/nodes/StartNode.tsx
+++ b/components/nodes/StartNode.tsx
@@ -1,0 +1,10 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function StartNode({ data }: NodeProps<NodeData>) {
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-center text-sm">
+      {data.label || 'Start'}
+    </div>
+  )
+}

--- a/components/nodes/WaitNode.tsx
+++ b/components/nodes/WaitNode.tsx
@@ -1,0 +1,11 @@
+'use client'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+export default function WaitNode({ data }: NodeProps<NodeData>) {
+  const delay = data.delay ?? 1
+  return (
+    <div className="p-2 bg-white rounded shadow w-40 text-sm text-center">
+      Wait {delay}s
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^19.0.0",
     "react-flow-renderer": "^10.3.17",
     "sonner": "^2.0.5",
-    "ui": "git+https://github.com/shadcn/ui.git"
+    "ui": "git+https://github.com/shadcn/ui.git",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       ui:
         specifier: git+https://github.com/shadcn/ui.git
         version: git+https://github.com/shadcn/ui.git#b1fd13ffb02e8449e4b118b7fd22134129746eed(@types/node@20.19.0)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
+      zustand:
+        specifier: ^5.0.5
+        version: 5.0.5(@types/react@19.1.7)(react@19.1.0)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -4755,6 +4758,24 @@ packages:
       react: '>=16.8'
     peerDependenciesMeta:
       react:
+        optional: true
+
+  zustand@5.0.5:
+    resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
         optional: true
 
 snapshots:
@@ -9965,4 +9986,9 @@ snapshots:
 
   zustand@3.7.2(react@19.1.0):
     optionalDependencies:
+      react: 19.1.0
+
+  zustand@5.0.5(@types/react@19.1.7)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.7
       react: 19.1.0

--- a/store/botBuilderStore.ts
+++ b/store/botBuilderStore.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import create from 'zustand'
+import { create } from 'zustand'
 import type { FileType } from '@/types'
 
 export type UploadedFile = {

--- a/store/flowStore.ts
+++ b/store/flowStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand'
+import { nanoid } from 'nanoid'
+import type { Node, Edge } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+import { getSupabaseClient } from '@/lib/supabaseClient'
+
+interface FlowState {
+  nodes: Node<NodeData>[]
+  edges: Edge[]
+  flowId: string | null
+  selected: Node<NodeData> | null
+  setNodes: (n: Node<NodeData>[]) => void
+  setEdges: (e: Edge[]) => void
+  setSelected: (n: Node<NodeData> | null) => void
+  load: (botId: string) => Promise<void>
+  save: (botId: string) => Promise<void>
+}
+
+export const useFlowStore = create<FlowState>((set, get) => ({
+  nodes: [],
+  edges: [],
+  flowId: null,
+  selected: null,
+  setNodes: (nodes) => set({ nodes }),
+  setEdges: (edges) => set({ edges }),
+  setSelected: (selected) => set({ selected }),
+  async load(botId) {
+    const supabase = getSupabaseClient()
+    const { data } = await supabase
+      .from('flows')
+      .select('*')
+      .eq('flowName', `bot-${botId}`)
+      .single()
+    if (data) {
+      set({ flowId: data.id, nodes: data.nodes || [], edges: data.edges || [] })
+    } else {
+      set({ nodes: [], edges: [], flowId: null })
+    }
+  },
+  async save(botId) {
+    const supabase = getSupabaseClient()
+    const payload = {
+      flowName: `bot-${botId}`,
+      nodes: get().nodes,
+      edges: get().edges,
+    }
+    if (get().flowId) {
+      await supabase.from('flows').update(payload).eq('id', get().flowId!)
+    } else {
+      const { data } = await supabase
+        .from('flows')
+        .insert(payload)
+        .select()
+        .single()
+      if (data) set({ flowId: data.id })
+    }
+  },
+}))

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,11 @@
 import type { Edge, Node } from 'react-flow-renderer'
 
 export type NodeData = {
+  label?: string
+  message?: string
+  delay?: number
+  url?: string
+  condition?: string
   prompt?: string
   tool?: string
   output?: string


### PR DESCRIPTION
## Summary
- extend node data types for new bot features
- add Zustand-based flowStore with Supabase sync
- create React Flow builder components and node types
- integrate BotFlowBuilder in bot builder page
- install zustand

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684afd60345483249458d239da568bad