### PR TITLE
Fix ts error and wrap ReactFlow

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-page-custom-font */
 import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -5,6 +6,7 @@ import { Toaster } from "sonner";
 export const metadata: Metadata = {
   title: "Atendor",
   description: "Atendor AI chatbot builder",
+  metadataBase: new URL("https://atendor.example.com"),
   openGraph: {
     title: "Atendor",
     description: "Atendor AI chatbot builder",

--- a/components/BotFlowBuilder.tsx
+++ b/components/BotFlowBuilder.tsx
@@ -12,6 +12,7 @@ import ReactFlow, {
   type Node,
   EdgeChange,
   NodeChange,
+  ReactFlowProvider,
 } from 'react-flow-renderer'
 import { nanoid } from 'nanoid'
 import { useFlowStore } from '@/store/flowStore'
@@ -44,7 +45,7 @@ const nodeTypes = {
 
 type Props = { botId: string; planLimit: number }
 
-export default function BotFlowBuilder({ botId, planLimit }: Props) {
+function BuilderContent({ botId, planLimit }: Props) {
   const [rfNodes, setRfNodes] = useState<Node<NodeData>[]>([])
   const [rfEdges, setRfEdges] = useState<Edge[]>([])
   const store = useFlowStore()
@@ -228,7 +229,10 @@ export default function BotFlowBuilder({ botId, planLimit }: Props) {
     setShowTemplates(false)
   }
 
-  const updateNodeData = (field: keyof NodeData, value: string | number) => {
+  const updateNodeData = (
+    field: keyof NodeData,
+    value: NodeData[keyof NodeData]
+  ) => {
     const node = store.selected
     if (!node) return
     setRfNodes((nds) =>
@@ -509,5 +513,13 @@ export default function BotFlowBuilder({ botId, planLimit }: Props) {
         </div>
       )}
     </div>
+  )
+}
+
+export default function BotFlowBuilder(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <BuilderContent {...props} />
+    </ReactFlowProvider>
   )
 }

--- a/components/VisualBuilder.tsx
+++ b/components/VisualBuilder.tsx
@@ -11,7 +11,7 @@ import ReactFlow, {
   useEdgesState,
   Connection,
   Node,
-  Edge,
+  ReactFlowProvider,
 } from 'react-flow-renderer'
 import PromptNode from './nodes/PromptNode'
 import ToolNode from './nodes/ToolNode'
@@ -25,7 +25,7 @@ const nodeTypes = {
   output: OutputNode,
 }
 
-export default function VisualBuilder({ flowName }: { flowName: string }) {
+function BuilderContent({ flowName }: { flowName: string }) {
   const { nodes: initialNodes, edges: initialEdges, setNodes, setEdges, save } =
     useFlowData(flowName)
 
@@ -38,14 +38,17 @@ export default function VisualBuilder({ flowName }: { flowName: string }) {
     _setEdges(initialEdges)
   }, [initialNodes, initialEdges, _setNodes, _setEdges])
 
-  const isValid = (connection: Connection) => {
-    const source = nodes.find((n) => n.id === connection.source)
-    const target = nodes.find((n) => n.id === connection.target)
-    if (!source || !target) return false
-    if (source.type === 'prompt' && target.type === 'tool') return true
-    if (source.type === 'tool' && target.type === 'output') return true
-    return false
-  }
+  const isValid = useCallback(
+    (connection: Connection) => {
+      const source = nodes.find((n) => n.id === connection.source)
+      const target = nodes.find((n) => n.id === connection.target)
+      if (!source || !target) return false
+      if (source.type === 'prompt' && target.type === 'tool') return true
+      if (source.type === 'tool' && target.type === 'output') return true
+      return false
+    },
+    [nodes]
+  )
 
   const onConnect = useCallback(
     (connection: Connection) => {
@@ -55,7 +58,7 @@ export default function VisualBuilder({ flowName }: { flowName: string }) {
         )
       }
     },
-    [nodes, _setEdges]
+    [isValid, _setEdges]
   )
 
   const onDragStart = (event: React.DragEvent, nodeType: string) => {
@@ -149,5 +152,13 @@ export default function VisualBuilder({ flowName }: { flowName: string }) {
         </button>
       </div>
     </div>
+  )
+}
+
+export default function VisualBuilder({ flowName }: { flowName: string }) {
+  return (
+    <ReactFlowProvider>
+      <BuilderContent flowName={flowName} />
+    </ReactFlowProvider>
   )
 }

--- a/lib/actions/files.ts
+++ b/lib/actions/files.ts
@@ -62,7 +62,7 @@ export class FilesCrud {
       throw new Error(`Unsupported extension ${extension}`)
     }
     const supabase = getSupabaseClient()
-    const { data, error } = await supabase.storage
+    const { error } = await supabase.storage
       .from('bot-files')
       .upload(`${botId}/${file.name}`, file, { upsert: true })
     if (error) throw new Error(error.message)

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  webpack: (config) => {
+    config.ignoreWarnings = [
+      /Critical dependency: the request of a dependency is an expression/,
+    ]
+    return config
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- extend `updateNodeData` to accept the correct NodeData values
- use ReactFlowProvider in VisualBuilder and BotFlowBuilder
- fix ESLint warnings and add custom webpack ignore rule
- handle supabase file upload variable
- set metadataBase and disable font warning

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b127d4d088324a790f800529406d2