### PR TITLE
Fix BotFlowBuilder JSX closing tag

### DIFF
--- a/components/BotFlowBuilder.tsx
+++ b/components/BotFlowBuilder.tsx
@@ -534,8 +534,8 @@ function BuilderContent({ botId, planLimit, botName }: Props) {
               Delete
             </button>
           </div>
-        )}
-      </aside>
+        </aside>
+      )}
       {showTemplates && (
         <div
           className="absolute inset-0 bg-black/50 flex items-center justify-center"

--- a/types/images.d.ts
+++ b/types/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
## Summary
- fix closing placement for `<aside>` conditional in BotFlowBuilder
- add svg type declarations to satisfy TypeScript

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b3533adac8324a6a9b32df728a08b