### PR TITLE
Finalize builder autosave and dashboard grid

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
-import Link from 'next/link'
+import MyBotsGrid from '@/components/dashboard/MyBotsGrid'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,26 +19,16 @@ export default async function DashboardPage() {
   if (!session) {
     return <p className="p-4">Unauthorized</p>
   }
-  const { data: flows } = await supabase
-    .from('flows')
-    .select('id, flowName')
+  const { data: bots } = await supabase
+    .from('bots')
+    .select('id, name, created_at')
     .eq('user_id', session.user.id)
     .order('created_at', { ascending: false })
 
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Your Flows</h1>
-      <Link
-        href="/dashboard/builder"
-        className="inline-block px-4 py-2 bg-black text-white rounded"
-      >
-        Create new flow
-      </Link>
-      <ul className="list-disc pl-6">
-        {flows?.map((flow) => (
-          <li key={flow.id}>{flow.flowName}</li>
-        ))}
-      </ul>
+      <h1 className="text-2xl font-bold">My Bots</h1>
+      {bots && <MyBotsGrid bots={bots} />}
     </div>
   )
 }

--- a/components/builder/InspectorPanel.tsx
+++ b/components/builder/InspectorPanel.tsx
@@ -1,0 +1,108 @@
+'use client'
+import type { Node } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+import { useBotBuilderStore } from '@/store/botBuilderStore'
+
+export default function InspectorPanel({ node, update, remove }: { node: Node<NodeData>; update: (field: keyof NodeData, value: NodeData[keyof NodeData]) => void; remove: () => void }) {
+  const files = useBotBuilderStore((s) => s.files)
+  return (
+    <aside className="fixed top-16 right-4 w-60 bg-white rounded shadow p-4 space-y-2 text-sm z-50">
+      <h2 className="font-semibold mb-2">Node Settings</h2>
+      <div>
+        {['send', 'start', 'end', 'webhook', 'file-search', 'http'].includes(node.type ?? '') && (
+          <div className="mb-2">
+            <label className="block mb-1" htmlFor="label">Label</label>
+            <input id="label" className="w-full border p-1" value={node.data.label || ''} onChange={(e) => update('label', e.target.value)} />
+          </div>
+        )}
+        <div className="mb-2">
+          <label className="block mb-1" htmlFor="description">Description</label>
+          <input id="description" className="w-full border p-1" value={node.data.description || ''} onChange={(e) => update('description', e.target.value)} />
+        </div>
+        <div className="mb-2">
+          <label className="block mb-1" htmlFor="color">Color</label>
+          <input id="color" type="color" className="w-full border p-1 h-8" value={node.data.color || '#ffffff'} onChange={(e) => update('color', e.target.value)} />
+        </div>
+        {node.type === 'send' && (
+          <div className="mb-2">
+            <label className="block mb-1" htmlFor="message">Message</label>
+            <textarea id="message" className="w-full border p-1" value={node.data.message || ''} onChange={(e) => update('message', e.target.value)} />
+          </div>
+        )}
+        {node.type === 'wait' && (
+          <div className="mb-2">
+            <label className="block mb-1" htmlFor="delay">Delay (s)</label>
+            <input id="delay" type="number" className="w-full border p-1" value={node.data.delay ?? 1} onChange={(e) => update('delay', Number(e.target.value))} />
+          </div>
+        )}
+        {node.type === 'http' && (
+          <div className="mb-2">
+            <label className="block mb-1" htmlFor="url">URL</label>
+            <input id="url" className="w-full border p-1" value={node.data.url || ''} onChange={(e) => update('url', e.target.value)} />
+          </div>
+        )}
+        {node.type === 'webhook' && (
+          <div className="space-y-2">
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="wh-url">Webhook URL</label>
+              <input id="wh-url" className="w-full border p-1" value={node.data.url || ''} onChange={(e) => update('url', e.target.value)} />
+            </div>
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="wh-method">Method</label>
+              <select id="wh-method" className="w-full border p-1" value={node.data.method || 'POST'} onChange={(e) => update('method', e.target.value)}>
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+              </select>
+            </div>
+          </div>
+        )}
+        {node.type === 'file-search' && (
+          <div className="space-y-2">
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="fs-file">File</label>
+              <select id="fs-file" className="w-full border p-1" value={node.data.fileId || ''} onChange={(e) => update('fileId', e.target.value)}>
+                <option value="">Select file</option>
+                {files.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="fs-prompt">User prompt</label>
+              <textarea id="fs-prompt" className="w-full border p-1" value={node.data.prompt || ''} onChange={(e) => update('prompt', e.target.value)} />
+            </div>
+          </div>
+        )}
+        {node.type === 'textNode' && (
+          <div className="space-y-2">
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="tn-text">Text</label>
+              <textarea id="tn-text" className="w-full border p-1" value={node.data.text || ''} onChange={(e) => update('text', e.target.value)} />
+            </div>
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="tn-font">Font</label>
+              <select id="tn-font" className="w-full border p-1" value={node.data.fontFamily || 'sans'} onChange={(e) => update('fontFamily', e.target.value as 'sans' | 'serif' | 'monospace')}>
+                <option value="sans">Sans</option>
+                <option value="serif">Serif</option>
+                <option value="monospace">Mono</option>
+              </select>
+            </div>
+            <div className="mb-2">
+              <label className="block mb-1" htmlFor="tn-size">Size</label>
+              <select id="tn-size" className="w-full border p-1" value={node.data.size || 'md'} onChange={(e) => update('size', e.target.value as 'sm' | 'md' | 'lg')}>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+              </select>
+            </div>
+          </div>
+        )}
+        <button onClick={remove} className="mt-2 bg-red-500 text-white px-2 py-1 rounded">
+          Delete
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/components/builder/NodePalette.tsx
+++ b/components/builder/NodePalette.tsx
@@ -1,0 +1,52 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+const NODE_TYPES = [
+  ['start', 'Start'],
+  ['send', 'Send Message'],
+  ['wait', 'Wait'],
+  ['input', 'Receive Input'],
+  ['file', 'File Lookup'],
+  ['file-search', 'File Search'],
+  ['textNode', 'Text'],
+  ['webhook', 'Webhook'],
+  ['http', 'HTTP Request'],
+  ['decision', 'Decision'],
+  ['end', 'End'],
+] as const
+
+export default function NodePalette({ onAdd }: { onAdd: (type: string) => void }) {
+  const [open, setOpen] = useState(false)
+  useEffect(() => {
+    setOpen(window.innerWidth >= 768)
+  }, [])
+  const onDragStart = (e: React.DragEvent, type: string) => {
+    e.dataTransfer.setData('application/reactflow', type)
+    e.dataTransfer.effectAllowed = 'move'
+  }
+  return (
+    <>
+      {open && (
+        <div className="fixed top-16 left-4 z-50 w-40 bg-white rounded shadow p-2 space-y-2 md:block">
+          {NODE_TYPES.map(([type, label]) => (
+            <div
+              key={type}
+              className="p-2 bg-white rounded shadow cursor-grab"
+              onDragStart={(e) => onDragStart(e, type)}
+              onClick={() => onAdd(type)}
+              draggable
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+      )}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="fixed top-16 left-4 z-50 md:hidden bg-white rounded shadow px-2 py-1"
+      >
+        {open ? 'Close' : 'Nodes'}
+      </button>
+    </>
+  )
+}

--- a/components/builder/TextNodeToolbar.tsx
+++ b/components/builder/TextNodeToolbar.tsx
@@ -1,0 +1,33 @@
+'use client'
+import type { Node } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+export default function TextNodeToolbar({ node, update }: { node: Node<NodeData>; update: (data: Partial<NodeData>) => void }) {
+  return (
+    <div
+      className="absolute z-50 bg-white rounded shadow p-1 space-x-1 text-xs"
+      style={{ left: node.position.x, top: node.position.y - 40 }}
+    >
+      <select
+        className="border text-xs"
+        value={node.data.fontFamily || 'sans'}
+        onChange={(e) =>
+          update({ fontFamily: e.target.value as 'sans' | 'serif' | 'monospace' })
+        }
+      >
+        <option value="sans">Sans</option>
+        <option value="serif">Serif</option>
+        <option value="monospace">Mono</option>
+      </select>
+      <select
+        className="border text-xs"
+        value={node.data.size || 'md'}
+        onChange={(e) => update({ size: e.target.value as 'sm' | 'md' | 'lg' })}
+      >
+        <option value="sm">Sm</option>
+        <option value="md">Md</option>
+        <option value="lg">Lg</option>
+      </select>
+    </div>
+  )
+}

--- a/components/builder/TopBar.tsx
+++ b/components/builder/TopBar.tsx
@@ -1,0 +1,39 @@
+'use client'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Home } from 'lucide-react'
+import logo from '@/assets/atendor-logo.svg'
+import { useUser } from '@/hooks/useUser'
+
+export type SavingState = 'saved' | 'saving' | 'error'
+
+export default function TopBar({ botName, onNameChange, saving }: { botName: string; onNameChange: (v: string) => void; saving: SavingState }) {
+  const { user } = useUser()
+  return (
+    <header className="fixed top-0 inset-x-0 h-12 flex items-center justify-between bg-white border-b px-4 z-50">
+      <div className="flex items-center space-x-2">
+        <Image src={logo} alt="Atendor" width={24} height={24} />
+        <Link href="/dashboard" className="flex items-center space-x-1 text-sm text-gray-600">
+          <Home className="w-4 h-4" />
+          <span>Back to Dashboard</span>
+        </Link>
+      </div>
+      <div className="flex items-center space-x-4">
+        <input
+          value={botName}
+          onChange={(e) => onNameChange(e.target.value)}
+          className="font-semibold text-center border-b border-transparent focus:border-gray-300 focus:outline-none"
+        />
+        <span className="text-xs">
+          {saving === 'saving' && '🟡 Saving…'}
+          {saving === 'saved' && '🟢 Saved'}
+          {saving === 'error' && '🔴 Disconnected'}
+        </span>
+        <button className="px-3 py-1 border rounded text-sm">Upgrade</button>
+        <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-xs">
+          {user?.email?.[0] ?? 'U'}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/dashboard/BotCard.tsx
+++ b/components/dashboard/BotCard.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { Star, MoreVertical } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+
+export type BotInfo = { id: string; name: string; created_at: string }
+
+export default function BotCard({ bot }: { bot: BotInfo }) {
+  const [fav, setFav] = useState(false)
+  const date = new Date(bot.created_at)
+  return (
+    <div className="border rounded p-4 relative hover:shadow">
+      <div className="absolute top-2 right-2 flex items-center space-x-1">
+        <button onClick={() => setFav((f) => !f)} aria-label="favorite">
+          <Star className={`w-4 h-4 ${fav ? 'fill-yellow-400 text-yellow-500' : ''}`} />
+        </button>
+        <details className="relative">
+          <summary className="list-none cursor-pointer">
+            <MoreVertical className="w-4 h-4" />
+          </summary>
+          <ul className="absolute right-0 mt-1 border bg-white rounded shadow text-sm">
+            <li>
+              <Link href={`/dashboard/bots/${bot.id}`} className="block px-2 py-1 hover:bg-gray-100">Open</Link>
+            </li>
+            <li>
+              <Link href={`/dashboard/bots/${bot.id}/builder`} className="block px-2 py-1 hover:bg-gray-100">Edit Flow</Link>
+            </li>
+          </ul>
+        </details>
+      </div>
+      <h3 className="font-bold text-lg mb-1">
+        <Link href={`/dashboard/bots/${bot.id}`}>{bot.name}</Link>
+      </h3>
+      <p className="text-xs text-gray-500">Created: {date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</p>
+    </div>
+  )
+}

--- a/components/dashboard/CreateBotCard.tsx
+++ b/components/dashboard/CreateBotCard.tsx
@@ -1,0 +1,12 @@
+'use client'
+import Link from 'next/link'
+import { Plus } from 'lucide-react'
+
+export default function CreateBotCard() {
+  return (
+    <Link href="/dashboard/bots/new" className="border-dashed border-2 rounded flex flex-col items-center justify-center p-4 hover:bg-gray-50">
+      <Plus className="w-6 h-6" />
+      <span className="mt-2">Create New Bot</span>
+    </Link>
+  )
+}

--- a/components/dashboard/MyBotsGrid.tsx
+++ b/components/dashboard/MyBotsGrid.tsx
@@ -1,0 +1,14 @@
+'use client'
+import BotCard, { BotInfo } from './BotCard'
+import CreateBotCard from './CreateBotCard'
+
+export default function MyBotsGrid({ bots }: { bots: BotInfo[] }) {
+  return (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+      {bots.map((b) => (
+        <BotCard key={b.id} bot={b} />
+      ))}
+      <CreateBotCard />
+    </div>
+  )
+}

--- a/components/nodes/TextNode.tsx
+++ b/components/nodes/TextNode.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { useState, useRef, useEffect } from 'react'
+import type { NodeProps } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+export default function TextNode({ data }: NodeProps<NodeData & { onChange?: (t: string) => void }>) {
+  const [editing, setEditing] = useState(false)
+  const [text, setText] = useState(data.text || 'Text')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus()
+    }
+  }, [editing])
+
+  const fontMap = {
+    sans: 'font-sans',
+    serif: 'font-serif',
+    monospace: 'font-mono',
+  } as const
+  const sizeMap = {
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-lg',
+  } as const
+
+  return (
+    <div
+      onDoubleClick={() => setEditing(true)}
+      className={`min-w-24 min-h-8 p-1 ${fontMap[data.fontFamily || 'sans']} ${sizeMap[data.size || 'md']}`}
+    >
+      {editing ? (
+        <textarea
+          ref={inputRef}
+          className="w-full border rounded p-1 text-black"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={() => {
+            setEditing(false)
+            data.onChange?.(text)
+          }}
+        />
+      ) : (
+        text
+      )}
+    </div>
+  )
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,6 +15,9 @@ export type NodeData = {
   tool?: string
   output?: string
   color?: string
+  text?: string
+  fontFamily?: 'sans' | 'serif' | 'monospace'
+  size?: 'sm' | 'md' | 'lg'
 }
 
 export type FlowType = {


### PR DESCRIPTION
## Summary
- add text node type and toolbar
- split builder UI into reusable components
- autosave flows and bot name to Supabase
- implement responsive My Bots grid on dashboard

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684b470ad7548324895a9edcc0eb2432