### PR TITLE
Add flow helpers and template utilities

### DIFF
--- a/components/BotFlowBuilder.tsx
+++ b/components/BotFlowBuilder.tsx
@@ -34,6 +34,7 @@ import TopBar, { SavingState } from './builder/TopBar'
 import NodePalette from './builder/NodePalette'
 import InspectorPanel from './builder/InspectorPanel'
 import TextNodeToolbar from './builder/TextNodeToolbar'
+import { createTemplate, TemplateName } from '@/utils/templates'
 
 const nodeTypes = {
   start: StartNode,
@@ -231,62 +232,8 @@ function BuilderContent({ botId, planLimit, botName }: Props) {
 
   // Templates
   const [showTemplates, setShowTemplates] = useState(false)
-  const applyTemplate = (name: string) => {
-    const base = [
-      { id: nanoid(), type: 'start', position: { x: 0, y: 0 }, data: {} },
-      { id: nanoid(), type: 'end', position: { x: 600, y: 0 }, data: {} },
-    ]
-    let nodes: Node<NodeData>[] = []
-    let edges: Edge[] = []
-    if (name === 'faq') {
-      nodes = [
-        base[0],
-        { id: nanoid(), type: 'input', position: { x: 150, y: 0 }, data: {} },
-        { id: nanoid(), type: 'file', position: { x: 300, y: 0 }, data: {} },
-        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: {} },
-        base[1],
-      ]
-    } else if (name === 'lead') {
-      nodes = [
-        base[0],
-        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: "What's your name?" } },
-        { id: nanoid(), type: 'input', position: { x: 300, y: 0 }, data: {} },
-        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: "What's your email?" } },
-        { id: nanoid(), type: 'input', position: { x: 600, y: 0 }, data: {} },
-        base[1],
-      ]
-    } else if (name === 'wa') {
-      nodes = [
-        base[0],
-        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'Hello! Welcome 👋' } },
-        { id: nanoid(), type: 'wait', position: { x: 300, y: 0 }, data: { delay: 2 } },
-        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: 'How can I help you today?' } },
-        base[1],
-      ]
-    } else if (name === 'booking') {
-      nodes = [
-        base[0],
-        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'What day would you like to book?' } },
-        { id: nanoid(), type: 'input', position: { x: 350, y: 0 }, data: {} },
-        { id: nanoid(), type: 'send', position: { x: 550, y: 0 }, data: { message: 'Booking confirmed!' } },
-        base[1],
-      ]
-    } else if (name === 'survey') {
-      nodes = [
-        base[0],
-        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'Rate us 1-5' } },
-        { id: nanoid(), type: 'input', position: { x: 300, y: 0 }, data: {} },
-        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: 'Thanks!' } },
-        base[1],
-      ]
-    }
-    // edges sequential
-    edges = nodes.slice(0, -1).map((n, i) => ({
-      id: nanoid(),
-      source: n.id,
-      target: nodes[i + 1].id,
-      type: 'smoothstep',
-    }))
+  const applyTemplate = (name: TemplateName) => {
+    const { nodes, edges } = createTemplate(name)
     if (nodes.length > planLimit) {
       toast.warning('Template exceeds plan limit. Extra nodes marked in red')
     }

--- a/store/flowStore.tsx
+++ b/store/flowStore.tsx
@@ -6,6 +6,10 @@ import type { Node, Edge } from 'react-flow-renderer'
 import type { NodeData } from '@/types'
 import { getSupabaseClient } from '@/lib/supabaseClient'
 
+/**
+ * Global builder store. Holds nodes, edges and helper methods.
+ * Use `useFlowStore` within `FlowStoreProvider` to read/update state.
+ */
 export interface FlowState {
   nodes: Node<NodeData>[]
   edges: Edge[]

--- a/utils/serialization.ts
+++ b/utils/serialization.ts
@@ -1,0 +1,17 @@
+import type { Node, Edge } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+/**
+ * Serialize nodes and edges to a JSON string. Useful for persisting flows.
+ */
+export function serializeFlow(nodes: Node<NodeData>[], edges: Edge[]): string {
+  return JSON.stringify({ nodes, edges })
+}
+
+/**
+ * Deserialize a flow from JSON.
+ */
+export function deserializeFlow(json: string): { nodes: Node<NodeData>[]; edges: Edge[] } {
+  const data = JSON.parse(json) as { nodes: Node<NodeData>[]; edges: Edge[] }
+  return { nodes: data.nodes || [], edges: data.edges || [] }
+}

--- a/utils/templates.ts
+++ b/utils/templates.ts
@@ -1,0 +1,75 @@
+import { nanoid } from 'nanoid'
+import type { Node, Edge } from 'react-flow-renderer'
+import type { NodeData } from '@/types'
+
+export type TemplateName = 'faq' | 'lead' | 'wa' | 'booking' | 'survey'
+export interface FlowTemplate {
+  nodes: Node<NodeData>[]
+  edges: Edge[]
+}
+
+/**
+ * Return predefined flow templates. Nodes come without plan limit marking.
+ */
+export function createTemplate(name: TemplateName): FlowTemplate {
+  const base: Node<NodeData>[] = [
+    { id: nanoid(), type: 'start', position: { x: 0, y: 0 }, data: {} },
+    { id: nanoid(), type: 'end', position: { x: 600, y: 0 }, data: {} },
+  ]
+  let nodes: Node<NodeData>[] = []
+  switch (name) {
+    case 'faq':
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'input', position: { x: 150, y: 0 }, data: {} },
+        { id: nanoid(), type: 'file', position: { x: 300, y: 0 }, data: {} },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: {} },
+        base[1],
+      ]
+      break
+    case 'lead':
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: "What's your name?" } },
+        { id: nanoid(), type: 'input', position: { x: 300, y: 0 }, data: {} },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: "What's your email?" } },
+        { id: nanoid(), type: 'input', position: { x: 600, y: 0 }, data: {} },
+        base[1],
+      ]
+      break
+    case 'wa':
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'Hello! Welcome \u{1F44B}' } },
+        { id: nanoid(), type: 'wait', position: { x: 300, y: 0 }, data: { delay: 2 } },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: 'How can I help you today?' } },
+        base[1],
+      ]
+      break
+    case 'booking':
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'What day would you like to book?' } },
+        { id: nanoid(), type: 'input', position: { x: 350, y: 0 }, data: {} },
+        { id: nanoid(), type: 'send', position: { x: 550, y: 0 }, data: { message: 'Booking confirmed!' } },
+        base[1],
+      ]
+      break
+    case 'survey':
+      nodes = [
+        base[0],
+        { id: nanoid(), type: 'send', position: { x: 150, y: 0 }, data: { message: 'Rate us 1-5' } },
+        { id: nanoid(), type: 'input', position: { x: 300, y: 0 }, data: {} },
+        { id: nanoid(), type: 'send', position: { x: 450, y: 0 }, data: { message: 'Thanks!' } },
+        base[1],
+      ]
+      break
+  }
+  const edges: Edge[] = nodes.slice(0, -1).map((n, i) => ({
+    id: nanoid(),
+    source: n.id,
+    target: nodes[i + 1].id,
+    type: 'smoothstep',
+  }))
+  return { nodes, edges }
+}


### PR DESCRIPTION
## Summary
- introduce `utils/serialization.ts` for saving/loading flows
- centralize example flows in `utils/templates.ts`
- expose builder store API with JSDoc comment
- refactor `BotFlowBuilder` to use new template helper

## Testing
- `pnpm build`
- `pnpm dev` (started then stopped)

------
https://chatgpt.com/codex/tasks/task_e_684bf348bce0832498da9d61bc155899